### PR TITLE
Fix Tilemap Position Bug

### DIFF
--- a/platformer-kit/entities/player/scripts/interactions/interaction_controller.gd
+++ b/platformer-kit/entities/player/scripts/interactions/interaction_controller.gd
@@ -35,7 +35,7 @@ func _ready() -> void:
 
 	$HurtboxShapecast.set_handler(InteractionTypes.Enemy, func(collider, _delta):
 		collider.death.emit()
-		player.position.y = collider.position.y - 16
+		player.position.y = collider.global_position.y - 16
 		player.enemy_bounce.emit()
 	)
 


### PR DESCRIPTION
Fix a bug in the platformer kit where if the tile map has a non-zero position the player appears to teleport. This was caused by using the mob's local position instead of its global position